### PR TITLE
unstdlib.standard.datetime_.now

### DIFF
--- a/unstdlib/standard/datetime_.py
+++ b/unstdlib/standard/datetime_.py
@@ -1,6 +1,10 @@
 import datetime
 
 
+__all__ = ['iterate_date', 'iterate_date_values', 'isoformat_as_datetime',
+           'truncate_datetime', 'now']
+
+
 def iterate_date(start, stop=None, step=datetime.timedelta(days=1)):
     while not stop or start <= stop:
         yield start
@@ -96,6 +100,7 @@ def now(timezone=None):
     d = d.replace(tzinfo=_UTC)
     d = timezone.normalize(d.astimezone(timezone))
     return d.replace(tzinfo=None)
+
 
 
 # Built-in timezone for when pytz isn't available:


### PR DESCRIPTION
Tried to pull in the most useful parts of the timezone branch into one utility method.
