### PR TITLE
Fix deprecated wrapper

### DIFF
--- a/unstdlib/standard/functools_.py
+++ b/unstdlib/standard/functools_.py
@@ -221,6 +221,7 @@ def deprecated(message, exception=PendingDeprecationWarning):
         ...     assert len(w) == 1
         ...     assert issubclass(w[-1].category, PendingDeprecationWarning)
         ...     assert message == str(w[-1].message)
+        ...     assert foo.__name__ == 'foo'
         8
     """
     def decorator(func):

--- a/unstdlib/standard/functools_.py
+++ b/unstdlib/standard/functools_.py
@@ -225,7 +225,7 @@ def deprecated(message, exception=PendingDeprecationWarning):
         8
     """
     def decorator(func):
-        wraps(func)
+        @wraps(func)
         def wrapper(*args, **kwargs):
             warnings.warn(message, exception, stacklevel=2)
             return func(*args, **kwargs)


### PR DESCRIPTION
Previously, the `wraps` decorator was never applied to the wrapper. I added the test in a separate commit in case you just wanted to omit it and just cherry-pick the fix.